### PR TITLE
Fix CMake

### DIFF
--- a/hebi/CMakeLists.txt
+++ b/hebi/CMakeLists.txt
@@ -18,9 +18,9 @@ if (UNIX AND NOT APPLE)
   # Detect cross-compilation, especially on the ROS build farm:
   if (${CMAKE_LIBRARY_ARCHITECTURE} MATCHES "^i[3456]86-linux-gnu$")
     set(LIBHEBI_TARGET_ARCHITECTURE "i686")
-  elseif ("arm-linux-gnueabihf" STREQUAL ${CMAKE_LIBRARY_ARCHITECTURE})
+  elseif ("arm-linux-gnueabihf" STREQUAL "${CMAKE_LIBRARY_ARCHITECTURE}")
     set(LIBHEBI_TARGET_ARCHITECTURE "armhf")
-  elseif ("aarch64-linux-gnu" STREQUAL ${CMAKE_LIBRARY_ARCHITECTURE})
+  elseif ("aarch64-linux-gnu" STREQUAL "${CMAKE_LIBRARY_ARCHITECTURE}")
     set(LIBHEBI_TARGET_ARCHITECTURE "aarch64")
   endif()
 


### PR DESCRIPTION
Otherwise this error occurs:
```
CMake Error at hebi/CMakeLists.txt:21 (elseif):
  given arguments:

    "arm-linux-gnueabihf" "STREQUAL"

  Unknown arguments specified
```

Fix validated in the RoboStack project: https://github.com/RoboStack/ros-noetic/